### PR TITLE
fix: show audio call length for locked expert calls

### DIFF
--- a/src/main/java/com/virtualpairprogrammers/tracker/messaging/MessageProcessor.java
+++ b/src/main/java/com/virtualpairprogrammers/tracker/messaging/MessageProcessor.java
@@ -33,6 +33,7 @@ public class MessageProcessor {
 				                          .withLat(new BigDecimal(incomingMessage.get("lat")))
 				                          .withLng(new BigDecimal(incomingMessage.get("long")))
 				                          .withTimestamp(convertedDatestamp)
+																	.withSpeed(47)
 				                          .build();
 				                          
 		data.updatePosition(newReport);


### PR DESCRIPTION
related to: ASE-139407